### PR TITLE
Ensure CI builds statically against core libraries

### DIFF
--- a/.github/workflows/build-and-upload-binaries-after-release.yaml
+++ b/.github/workflows/build-and-upload-binaries-after-release.yaml
@@ -25,7 +25,7 @@ jobs:
             asset-name: thrift-${{ github.ref_name }}-darwin-arm64.tar.gz
             install-deps: brew install automake bison flex cmake && echo "PATH=$(brew --prefix bison)/bin:$PATH" >> $GITHUB_ENV
             build-command: cmake --build .
-            cmake-parameters: '-G "Xcode"'
+            cmake-parameters: -G "Xcode"
           - platform: Linux ARM64
             os: ubuntu-latest
             artifact-path: compiler/cpp/cmake-build/bin

--- a/.github/workflows/build-and-upload-binaries-after-release.yaml
+++ b/.github/workflows/build-and-upload-binaries-after-release.yaml
@@ -18,6 +18,7 @@ jobs:
             asset-name: thrift-${{ github.ref_name }}-linux-amd64.tar.gz
             install-deps: sudo apt install -yq automake bison flex cmake
             build-command: make
+            cmake-parameters: -DSTATIC=ON
           - platform: Macos ARM64
             os: macos-latest
             artifact-path: compiler/cpp/cmake-build/bin/Debug
@@ -32,6 +33,7 @@ jobs:
             install-deps: sudo apt install -yq automake bison flex cmake g++-aarch64-linux-gnu
             cmake-parameters: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/build/cmake/Linux-ARM64.cmake"
             build-command: make
+            cmake-parameters: -DSTATIC=ON
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-and-upload-binaries-after-release.yaml
+++ b/.github/workflows/build-and-upload-binaries-after-release.yaml
@@ -18,7 +18,7 @@ jobs:
             asset-name: thrift-${{ github.ref_name }}-linux-amd64.tar.gz
             install-deps: sudo apt install -yq automake bison flex cmake
             build-command: make
-            cmake-parameters: '-DSTATIC=ON'
+            cmake-parameters: -DSTATIC=ON
           - platform: Macos ARM64
             os: macos-latest
             artifact-path: compiler/cpp/cmake-build/bin/Debug
@@ -31,9 +31,8 @@ jobs:
             artifact-path: compiler/cpp/cmake-build/bin
             asset-name: thrift-${{ github.ref_name }}-linux-arm64.tar.gz
             install-deps: sudo apt install -yq automake bison flex cmake g++-aarch64-linux-gnu
-            cmake-parameters: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/build/cmake/Linux-ARM64.cmake"
             build-command: make
-            cmake-parameters: '-DSTATIC=ON'
+            cmake-parameters: -DSTATIC=ON -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/build/cmake/Linux-ARM64.cmake"
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build-and-upload-binaries-after-release.yaml
+++ b/.github/workflows/build-and-upload-binaries-after-release.yaml
@@ -18,14 +18,14 @@ jobs:
             asset-name: thrift-${{ github.ref_name }}-linux-amd64.tar.gz
             install-deps: sudo apt install -yq automake bison flex cmake
             build-command: make
-            cmake-parameters: -DSTATIC=ON
+            cmake-parameters: '-DSTATIC=ON'
           - platform: Macos ARM64
             os: macos-latest
             artifact-path: compiler/cpp/cmake-build/bin/Debug
             asset-name: thrift-${{ github.ref_name }}-darwin-arm64.tar.gz
             install-deps: brew install automake bison flex cmake && echo "PATH=$(brew --prefix bison)/bin:$PATH" >> $GITHUB_ENV
             build-command: cmake --build .
-            cmake-parameters: -G "Xcode"
+            cmake-parameters: '-G "Xcode"'
           - platform: Linux ARM64
             os: ubuntu-latest
             artifact-path: compiler/cpp/cmake-build/bin
@@ -33,7 +33,7 @@ jobs:
             install-deps: sudo apt install -yq automake bison flex cmake g++-aarch64-linux-gnu
             cmake-parameters: -DCMAKE_TOOLCHAIN_FILE="$GITHUB_WORKSPACE/build/cmake/Linux-ARM64.cmake"
             build-command: make
-            cmake-parameters: -DSTATIC=ON
+            cmake-parameters: '-DSTATIC=ON'
 
     steps:
       - uses: actions/checkout@v2

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -104,6 +104,17 @@ THRIFT_ADD_COMPILER(swift   "Enable compiler for Cocoa Swift" ON)
 THRIFT_ADD_COMPILER(xml     "Enable compiler for XML" ON)
 THRIFT_ADD_COMPILER(xsd     "Enable compiler for XSD" ON)
 
+option(STATIC "Enable static linking of core libraries (libgcc / libstdc++)")
+
+set(thrift-compiler_LINKER_FLAGS)
+
+if(STATIC)
+    set(thrift-compiler_LINKER_FLAGS
+        -static-libgcc
+        -static-libstdc++
+    )
+endif()
+
 # Thrift is looking for include files in the src directory
 # we also add the current binary directory for generated files
 include_directories(${CMAKE_CURRENT_BINARY_DIR} src)
@@ -115,7 +126,7 @@ add_executable(thrift-compiler ${thrift-compiler_SOURCES})
 set_target_properties(thrift-compiler PROPERTIES RUNTIME_OUTPUT_DIRECTORY bin/)
 set_target_properties(thrift-compiler PROPERTIES OUTPUT_NAME thrift)
 
-target_link_libraries(thrift-compiler parse)
+target_link_libraries(thrift-compiler parse ${thrift-compiler_LINKER_FLAGS})
 
 add_custom_command(OUTPUT "${CMAKE_CURRENT_SOURCE_DIR}/thrift${CMAKE_EXECUTABLE_SUFFIX}"
     DEPENDS thrift-compiler


### PR DESCRIPTION
To avoid potential incompatibilities with shared libraries available on systems where `thrift` is being run later.
