### PR TITLE
add responsibility to change callback field name in js

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   compiler:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
 

--- a/ApacheThrift.nuspec
+++ b/ApacheThrift.nuspec
@@ -4,9 +4,9 @@
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
   You may obtain a copy of the License at
-  
+
       http://www.apache.org/licenses/LICENSE-2.0
-  
+
   Unless required by applicable law or agreed to in writing, software
   distributed under the License is distributed on an "AS IS" BASIS,
   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -25,8 +25,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2013/05/nuspec.xsd">
   <metadata>
     <id>ApacheThrift</id>
-    <version>0.20.0</version>
-    <title>Apache Thrift 0.20.0</title>
+    <version>0.20.1</version>
+    <title>Apache Thrift 0.20.1</title>
     <authors>Apache Thrift Developers</authors>
     <owners>Apache Software Foundation</owners>
     <license type="expression">Apache-2.0</license>

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,7 @@ endif()
 
 # PACKAGE_VERSION is used by cpack scripts currently
 # Both thrift_VERSION and PACKAGE_VERSION should be the same for now
-set(thrift_VERSION "0.20.0")
+set(thrift_VERSION "0.20.1")
 set(PACKAGE_VERSION ${thrift_VERSION})
 
 project("thrift" VERSION ${PACKAGE_VERSION})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.16)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)  # package version behavior added in cmake 3.0

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.4)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 if(POLICY CMP0048)
   cmake_policy(SET CMP0048 NEW)  # package version behavior added in cmake 3.0

--- a/Thrift.podspec
+++ b/Thrift.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'Thrift'
-  s.version       = '0.20.0'
+  s.version       = '0.20.1'
   s.summary       = "Apache Thrift is a lightweight, language-independent software stack with an associated code generation mechanism for RPC."
   s.description   = <<-DESC
 The Apache Thrift scalable cross-language software framework for networked services development combines a software stack with a code generation engine to build services that work efficiently and seamlessly between many programming languages.

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -19,7 +19,7 @@
 
 # build Apache Thrift on AppVeyor - https://ci.appveyor.com
 
-version: '0.20.0.{build}'
+version: '0.20.1.{build}'
 
 shallow_clone: true
 

--- a/bower.json
+++ b/bower.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "homepage": "https://github.com/apache/thrift.git",
   "authors": [
     "Apache Thrift <dev@thrift.apache.org>"

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.3)
+cmake_minimum_required(VERSION 3.5...3.31)
 project("thrift-compiler" VERSION ${PACKAGE_VERSION})
 
 # version.h now handled via veralign.sh

--- a/compiler/cpp/CMakeLists.txt
+++ b/compiler/cpp/CMakeLists.txt
@@ -17,7 +17,7 @@
 # under the License.
 #
 
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.16)
 project("thrift-compiler" VERSION ${PACKAGE_VERSION})
 
 # version.h now handled via veralign.sh

--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -225,9 +225,12 @@ public:
   std::string get_import_path(t_program* program);
   std::string declare_field(t_field* tfield, bool init = false, bool obj = false);
   std::string function_signature(t_function* tfunction,
-                                 std::string prefix = "",
-                                 bool include_callback = false);
-  std::string argument_list(t_struct* tstruct, bool include_callback = false);
+                               std::string prefix = "",
+                               bool include_callback = false,
+                               const std::string& callback_name = "callback");
+  std::string argument_list(t_struct* tstruct,
+                          bool include_callback = false,
+                          const std::string& callback_name = "callback");
   std::string type_to_enum(t_type* ttype);
   std::string make_valid_nodeJs_identifier(std::string const& name);
   std::string next_identifier_name(std::vector<t_field*> const& fields, std::string const& base_name);
@@ -313,8 +316,9 @@ public:
    * TypeScript Definition File helper functions
    */
 
-  string ts_function_signature(t_function* tfunction, bool include_callback);
-  string ts_get_type(t_type* type);
+string ts_function_signature(t_function* tfunction,
+                             bool include_callback,
+                             const std::string& callback_name = "callback");
 
   /**
    * Special indentation for TypeScript Definitions because of the module.
@@ -927,9 +931,9 @@ void t_js_generator::generate_js_struct_definition(ostream& out,
 
       // Special case. Exceptions derive from Error, and error has a non optional message field.
       // Ignore the optional flag in this case, otherwise we will generate a incompatible field
-      // in the eyes of typescript. 
+      // in the eyes of typescript.
       string optional_flag = is_exception && member_name == "message" ? "" : ts_get_req(*m_iter);
- 
+
       f_types_ts_ << ts_indent() << ts_access << member_name << optional_flag << ": "
                   << ts_get_type((*m_iter)->get_type()) << ";" << endl;
     }
@@ -1830,6 +1834,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
   for (f_iter = functions.begin(); f_iter != functions.end(); ++f_iter) {
     t_struct* arg_struct = (*f_iter)->get_arglist();
     const vector<t_field*>& fields = arg_struct->get_members();
+    const std::string callback_name = next_identifier_name(fields, "callback");
     vector<t_field*>::const_iterator fld_iter;
     string funname = (*f_iter)->get_name();
     string arglist = argument_list(arg_struct);
@@ -1840,20 +1845,20 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << funname << " (" << arglist << ") {" << endl;
     } else {
       indent(f_service_) << js_namespace(tservice->get_program()) << service_name_ << "Client.prototype."
-                << function_signature(*f_iter, "", !gen_es6_) << " {" << endl;
+                << function_signature(*f_iter, "", !gen_es6_, callback_name) << " {" << endl;
     }
 
     indent_up();
 
     if (gen_ts_) {
       // function definition without callback
-      f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, false) << endl;
+      f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, false, callback_name) << endl;
       if (!gen_es6_) {
         // overload with callback
-        f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, true) << endl;
+        f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, true, callback_name) << endl;
       } else {
         // overload with callback
-        f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, true) << endl;
+        f_service_ts_ << ts_print_doc(*f_iter) << ts_indent() << ts_function_signature(*f_iter, true, callback_name) << endl;
       }
     }
 
@@ -1872,7 +1877,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       indent(f_service_) << "});" << endl;
     } else if (gen_node_) { // Node.js output      ./gen-nodejs
       f_service_ << indent() << "this._seqid = this.new_seqid();" << endl << indent()
-                 << "if (callback === undefined) {" << endl;
+                 << "if (" << callback_name << " === undefined) {" << endl;
       indent_up();
       f_service_ << indent() << js_const_type_ << "_defer = Q.defer();" << endl << indent()
                  << "this._reqs[this.seqid()] = function(error, result) {" << endl;
@@ -1893,7 +1898,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       indent_down();
       indent(f_service_) << "} else {" << endl;
       indent_up();
-      f_service_ << indent() << "this._reqs[this.seqid()] = callback;" << endl << indent()
+      f_service_ << indent() << "this._reqs[this.seqid()] = " << callback_name << ";" << endl << indent()
                  << "this.send_" << funname << "(" << arglist << ");" << endl;
       indent_down();
       indent(f_service_) << "}" << endl;
@@ -1911,7 +1916,7 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       f_service_ << indent() << "});" << endl;
 
     } else if (gen_jquery_) { // jQuery output       ./gen-js
-      f_service_ << indent() << "if (callback === undefined) {" << endl;
+      f_service_ << indent() << "if (" << callback_name << " === undefined) {" << endl;
       indent_up();
       f_service_ << indent() << "this.send_" << funname << "(" << arglist << ");" << endl;
       if (!(*f_iter)->is_oneway()) {
@@ -1935,9 +1940,9 @@ void t_js_generator::generate_service_client(t_service* tservice) {
       f_service_ << indent() << "}" << endl;
     } else { // Standard JavaScript ./gen-js
       f_service_ << indent() << "this.send_" << funname << "(" << arglist
-                 << (arglist.empty() ? "" : ", ") << "callback); " << endl;
+                 << (arglist.empty() ? "" : ", ") << callback_name << "); " << endl;
       if (!(*f_iter)->is_oneway()) {
-        f_service_ << indent() << "if (!callback) {" << endl;
+        f_service_ << indent() << "if (!" << callback_name << ") {" << endl;
         f_service_ << indent();
         if (!(*f_iter)->get_returntype()->is_void()) {
           f_service_ << "  return ";
@@ -2643,14 +2648,11 @@ string t_js_generator::declare_field(t_field* tfield, bool init, bool obj) {
  */
 string t_js_generator::function_signature(t_function* tfunction,
                                           string prefix,
-                                          bool include_callback) {
-
+                                          bool include_callback,
+                                          const std::string& callback_name) {
   string str;
-
   str = prefix + tfunction->get_name() + " = function(";
-
-  str += argument_list(tfunction->get_arglist(), include_callback);
-
+  str += argument_list(tfunction->get_arglist(), include_callback, callback_name);
   str += ")";
   return str;
 }
@@ -2658,9 +2660,10 @@ string t_js_generator::function_signature(t_function* tfunction,
 /**
  * Renders a field list
  */
-string t_js_generator::argument_list(t_struct* tstruct, bool include_callback) {
+string t_js_generator::argument_list(t_struct* tstruct,
+                                     bool include_callback,
+                                     const std::string& callback_name) {
   string result = "";
-
   const vector<t_field*>& fields = tstruct->get_members();
   vector<t_field*>::const_iterator f_iter;
   bool first = true;
@@ -2677,7 +2680,7 @@ string t_js_generator::argument_list(t_struct* tstruct, bool include_callback) {
     if (!fields.empty()) {
       result += ", ";
     }
-    result += "callback";
+    result += callback_name;
   }
 
   return result;
@@ -2818,7 +2821,9 @@ string t_js_generator::ts_get_type(t_type* type) {
  * @param bool in-/exclude the callback argument
  * @return String of rendered function definition
  */
-std::string t_js_generator::ts_function_signature(t_function* tfunction, bool include_callback) {
+std::string t_js_generator::ts_function_signature(t_function* tfunction,
+                                                  bool include_callback,
+                                                  const std::string& callback_name) {
   string str;
   const vector<t_field*>& fields = tfunction->get_arglist()->get_members();
   vector<t_field*>::const_iterator f_iter;
@@ -2857,12 +2862,12 @@ std::string t_js_generator::ts_function_signature(t_function* tfunction, bool in
         }
       }
       if (exception_types == "") {
-        str += "callback: (error: void, response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+        str += callback_name + ": (error: void, response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
       } else {
-        str += "callback: (error: " + exception_types + ", response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+        str += callback_name + ": (error: " + exception_types + ", response: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
       }
     } else {
-      str += "callback: (data: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
+      str += callback_name + ": (data: " + ts_get_type(tfunction->get_returntype()) + ")=>void): ";
     }
 
     if (gen_jquery_) {

--- a/compiler/cpp/src/thrift/generate/t_js_generator.cc
+++ b/compiler/cpp/src/thrift/generate/t_js_generator.cc
@@ -319,7 +319,7 @@ public:
 string ts_function_signature(t_function* tfunction,
                              bool include_callback,
                              const std::string& callback_name = "callback");
-
+string ts_get_type(t_type* type);
   /**
    * Special indentation for TypeScript Definitions because of the module.
    * Returns the normal indentation + "  " if a module was defined.

--- a/compiler/cpp/src/thrift/version.h
+++ b/compiler/cpp/src/thrift/version.h
@@ -24,6 +24,6 @@
 #pragma once
 #endif // _MSC_VER
 
-#define THRIFT_VERSION "0.20.0"
+#define THRIFT_VERSION "0.20.1"
 
 #endif // _THRIFT_VERSION_H_

--- a/compiler/cpp/tests/CMakeLists.txt
+++ b/compiler/cpp/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.5...3.31)
 
 project(thrift_compiler_tests)
 
@@ -61,7 +61,7 @@ add_library(parse STATIC ${parse_SOURCES})
 set(thrift_compiler_tests
 )
 
-# you can add some files manually there 
+# you can add some files manually there
 set(thrift_compiler_tests_manual_SOURCES
     # tests file to avoid main in every test file
     ${CMAKE_CURRENT_SOURCE_DIR}/tests_main.cc

--- a/compiler/cpp/tests/CMakeLists.txt
+++ b/compiler/cpp/tests/CMakeLists.txt
@@ -16,7 +16,7 @@
 # specific language governing permissions and limitations
 # under the License.
 #
-cmake_minimum_required(VERSION 3.5...3.31)
+cmake_minimum_required(VERSION 3.16)
 
 project(thrift_compiler_tests)
 

--- a/configure.ac
+++ b/configure.ac
@@ -20,7 +20,7 @@
 AC_PREREQ(2.65)
 AC_CONFIG_MACRO_DIR([./aclocal])
 
-AC_INIT([thrift], [0.20.0])
+AC_INIT([thrift], [0.20.1])
 
 AC_CONFIG_AUX_DIR([.])
 

--- a/contrib/Rebus/Properties/AssemblyInfo.cs
+++ b/contrib/Rebus/Properties/AssemblyInfo.cs
@@ -34,5 +34,5 @@ using System.Runtime.InteropServices;
 
 [assembly: Guid("0af10984-40d3-453d-b1e5-421529e8c7e2")]
 
-[assembly: AssemblyVersion("0.20.0.0")]
-[assembly: AssemblyFileVersion("0.20.0.0")]
+[assembly: AssemblyVersion("0.20.1.0")]
+[assembly: AssemblyFileVersion("0.20.1.0")]

--- a/contrib/thrift-maven-plugin/pom.xml
+++ b/contrib/thrift-maven-plugin/pom.xml
@@ -29,7 +29,7 @@
   <artifactId>thrift-maven-plugin</artifactId>
   <packaging>maven-plugin</packaging>
   <name>thrift-maven-plugin</name>
-  <version>0.20.0</version>
+  <version>0.20.1</version>
 
   <properties>
     <maven.compiler.source>1.8</maven.compiler.source>

--- a/contrib/thrift.spec
+++ b/contrib/thrift.spec
@@ -28,7 +28,7 @@ Name:           thrift
 License:        Apache License v2.0
 Group:          Development
 Summary:        RPC and serialization framework
-Version:        0.20.0
+Version:        0.20.1
 Release:        0
 URL:            http://thrift.apache.org
 Packager:       Thrift Developers <dev@thrift.apache.org>
@@ -248,5 +248,5 @@ umask 007
 %changelog
 * Wed Aug 21 2013 Thrift Dev <dev@thrift.apache.org>
 - Thrift 0.9.1 release.
-* Wed Oct 10 2012 Thrift Dev <dev@thrift.apache.org> 
+* Wed Oct 10 2012 Thrift Dev <dev@thrift.apache.org>
 - Thrift 0.9.0 release.

--- a/contrib/zeromq/csharp/AssemblyInfo.cs
+++ b/contrib/zeromq/csharp/AssemblyInfo.cs
@@ -36,7 +36,7 @@ using System.Runtime.CompilerServices;
 // The form "{Major}.{Minor}.*" will automatically update the build and revision,
 // and "{Major}.{Minor}.{Build}.*" will update just the revision.
 
-[assembly: AssemblyVersion("0.20.0.0")]
+[assembly: AssemblyVersion("0.20.1.0")]
 
 // The following attributes are used to specify the signing key for the assembly,
 // if desired. See the Mono documentation for more information about signing.

--- a/doc/specs/idl.md
+++ b/doc/specs/idl.md
@@ -1,6 +1,6 @@
 ## Thrift interface description language
 
-For Thrift version 0.20.0.
+For Thrift version 0.20.1.
 
 The Thrift interface definition language (IDL) allows for the definition of [Thrift Types](/docs/types). A Thrift IDL file is processed by the Thrift code generator to produce code for the various target languages to support the defined structs and services in the IDL file.
 

--- a/lib/d/src/thrift/base.d
+++ b/lib/d/src/thrift/base.d
@@ -50,7 +50,7 @@ class TCompoundOperationException : TException {
 /// The Thrift version string, used for informative purposes.
 // Note: This is currently hardcoded, but will likely be filled in by the build
 // system in future versions.
-enum VERSION = "0.20.0";
+enum VERSION = "0.20.1";
 
 /**
  * Functions used for logging inside Thrift.

--- a/lib/dart/pubspec.yaml
+++ b/lib/dart/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: thrift
-version: 0.20.0
+version: 0.20.1
 description: >
   A Dart library for Apache Thrift
 author: Apache Thrift Developers <dev@thrift.apache.org>

--- a/lib/delphi/src/Thrift.pas
+++ b/lib/delphi/src/Thrift.pas
@@ -28,7 +28,7 @@ uses
   Thrift.Protocol;
 
 const
-  Version = '0.20.0';
+  Version = '0.20.1';
 
 type
   TException = Thrift.Exception.TException; // compatibility alias

--- a/lib/erl/src/thrift.app.src
+++ b/lib/erl/src/thrift.app.src
@@ -22,7 +22,7 @@
     {description, "Thrift bindings"},
 
   % The version of the applicaton
-  {vsn, "0.20.0"},
+  {vsn, "0.20.1"},
 
     % All modules used by the application.
     {modules, []},

--- a/lib/haxe/haxelib.json
+++ b/lib/haxe/haxelib.json
@@ -3,17 +3,17 @@
 	"url" : "http://thrift.apache.org",
 	"license": "Apache",
 	"tags": [
-		"thrift", 
-		"rpc", 
-		"serialization", 
-		"cross", 
+		"thrift",
+		"rpc",
+		"serialization",
+		"cross",
 		"framework"
 	],
 	"description": "Haxe bindings for the Apache Thrift RPC and serialization framework",
-	"version": "0.20.0",
+	"version": "0.20.1",
 	"releasenote": "Licensed under Apache License, Version 2.0. The Apache Thrift compiler needs to be installed separately.",
 	"contributors": ["ApacheThrift"],
-	"dependencies": { 
+	"dependencies": {
 		"crypto": "",
 		"uuid": ""
 	},

--- a/lib/java/gradle.properties
+++ b/lib/java/gradle.properties
@@ -1,7 +1,7 @@
 # This file is shared currently between this Gradle build and the
 # Ant builds for fd303 and JavaScript. Keep the dotted notation for
 # the properties to minimize the changes in the dependencies.
-thrift.version=0.20.0
+thrift.version=0.20.1
 thrift.groupid=org.apache.thrift
 release=false
 

--- a/lib/java/gradle/unitTests.gradle
+++ b/lib/java/gradle/unitTests.gradle
@@ -79,7 +79,7 @@ test {
     maxHeapSize = '512m'
 
     systemProperties = [
-        'build.test': "${compileTestJava.destinationDir}",
+        'build.test': "${compileTestJava.destinationDirectory}",
         'test.port': "${testPort}",
         'javax.net.ssl.trustStore': "${projectDir}/src/crossTest/resources/.truststore",
         'javax.net.ssl.trustStorePassword': 'thrift',

--- a/lib/java/gradle/unitTests.gradle
+++ b/lib/java/gradle/unitTests.gradle
@@ -79,11 +79,10 @@ test {
     maxHeapSize = '512m'
 
     systemProperties = [
-        'build.test': "${compileTestJava.destinationDirectory}",
         'test.port': "${testPort}",
         'javax.net.ssl.trustStore': "${projectDir}/src/crossTest/resources/.truststore",
         'javax.net.ssl.trustStorePassword': 'thrift',
-        'javax.net.ssl.keyStore': "${projectDir}/src/crossTest/resources/.keystore",
+        'javax.net.ssl.keyStore': "${projectDir}/src/crossTest/resources/.serverkeystore",
         'javax.net.ssl.keyStorePassword': 'thrift'
     ]
 }

--- a/lib/js/package-lock.json
+++ b/lib/js/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thrift",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "devDependencies": {
         "browserify": "~16.5",

--- a/lib/js/package.json
+++ b/lib/js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Thrift is a software framework for scalable cross-language services development.",
   "main": "./src/thrift",
   "author": {

--- a/lib/js/src/thrift.js
+++ b/lib/js/src/thrift.js
@@ -46,7 +46,7 @@ var Thrift = {
      * @const {string} Version
      * @memberof Thrift
      */
-    Version: '0.20.0',
+    Version: '0.20.1',
 
     /**
      * Thrift IDL type string to Id mapping.

--- a/lib/lua/Thrift.lua
+++ b/lib/lua/Thrift.lua
@@ -48,7 +48,7 @@ function ttable_size(t)
   return count
 end
 
-version = '0.20.0'
+version = '0.20.1'
 
 TType = {
   STOP   = 0,

--- a/lib/netstd/Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
+++ b/lib/netstd/Tests/Thrift.IntegrationTests/Thrift.IntegrationTests.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -23,7 +23,7 @@
     <LangVersion>latestMajor</LangVersion>
     <AssemblyName>Thrift.IntegrationTests</AssemblyName>
     <PackageId>Thrift.IntegrationTests</PackageId>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>

--- a/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.PublicInterfaces.Compile.Tests/Thrift.PublicInterfaces.Compile.Tests.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -19,7 +19,7 @@
   -->
 
   <PropertyGroup>
-    <ThriftVersion>0.20.0</ThriftVersion>
+    <ThriftVersion>0.20.1</ThriftVersion>
     <ThriftVersionOutput>Thrift version $(ThriftVersion)</ThriftVersionOutput>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>

--- a/lib/netstd/Tests/Thrift.Tests/Thrift.Tests.csproj
+++ b/lib/netstd/Tests/Thrift.Tests/Thrift.Tests.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -21,7 +21,7 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <LangVersion>latestMajor</LangVersion>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/lib/netstd/Thrift/Properties/AssemblyInfo.cs
+++ b/lib/netstd/Thrift/Properties/AssemblyInfo.cs
@@ -5,9 +5,9 @@
 // to you under the Apache License, Version 2.0 (the
 // "License"); you may not use this file except in compliance
 // with the License. You may obtain a copy of the License at
-// 
+//
 //     http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing,
 // software distributed under the License is distributed on an
 // "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -52,5 +52,5 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers
 // by using the '*' as shown below:
 
-[assembly: AssemblyVersion("0.20.0.0")]
-[assembly: AssemblyFileVersion("0.20.0.0")]
+[assembly: AssemblyVersion("0.20.1.0")]
+[assembly: AssemblyFileVersion("0.20.1.0")]

--- a/lib/netstd/Thrift/Thrift.csproj
+++ b/lib/netstd/Thrift/Thrift.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -40,8 +40,8 @@
     <SignAssembly>true</SignAssembly>
     <AssemblyOriginatorKeyFile>thrift.snk</AssemblyOriginatorKeyFile>
     <DelaySign>false</DelaySign>
-    <Title>Apache Thrift 0.20.0</Title>
-    <Version>0.20.0.0</Version>
+    <Title>Apache Thrift 0.20.1</Title>
+    <Version>0.20.1.0</Version>
     <GeneratePackageOnBuild>false</GeneratePackageOnBuild>
     <PackageProjectUrl>http://thrift.apache.org/</PackageProjectUrl>
     <Authors>Apache Thrift Developers</Authors>
@@ -72,7 +72,7 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App" Condition="'$(TargetFramework.StartsWith(`netstandard2.`))' == 'false'" />
   </ItemGroup>
-	
+
   <ItemGroup>
     <PackageReference Update="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.3" />
   </ItemGroup>
@@ -86,7 +86,7 @@
       <Version>7.0.9</Version>
     </PackageReference>
   </ItemGroup>
-	
+
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0'">
 		<PackageReference Include="Microsoft.AspNetCore.Components.Web">
 			<Version>8.0.0</Version>

--- a/lib/ocaml/_oasis
+++ b/lib/ocaml/_oasis
@@ -1,5 +1,5 @@
 Name: libthrift-ocaml
-Version: 0.20.0
+Version: 0.20.1
 OASISFormat: 0.3
 Synopsis: OCaml bindings for the Apache Thrift RPC system
 Authors: Apache Thrift Developers <dev@thrift.apache.org>

--- a/lib/perl/lib/Thrift.pm
+++ b/lib/perl/lib/Thrift.pm
@@ -31,6 +31,6 @@ use warnings;
 #
 
 package Thrift;
-use version 0.77; our $VERSION = version->declare("v0.20.0");
+use version 0.77; our $VERSION = version->declare("v0.20.1");
 
 1;

--- a/lib/py/setup.py
+++ b/lib/py/setup.py
@@ -105,7 +105,7 @@ def run_setup(with_binary):
     twisted_deps = ['twisted']
 
     setup(name='thrift',
-          version='0.20.0',
+          version='0.20.1',
           description='Python bindings for the Apache Thrift RPC system',
           long_description=read_file("README.md"),
           long_description_content_type="text/markdown",

--- a/lib/rb/thrift.gemspec
+++ b/lib/rb/thrift.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path("../lib", __FILE__)
 
 Gem::Specification.new do |s|
   s.name        = 'thrift'
-  s.version     = '0.20.0'
+  s.version     = '0.20.1'
   s.authors     = ['Apache Thrift Developers']
   s.email       = ['dev@thrift.apache.org']
   s.homepage    = 'http://thrift.apache.org'

--- a/lib/rs/Cargo.toml
+++ b/lib/rs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "thrift"
 description = "Rust bindings for the Apache Thrift RPC system"
 edition = "2021"
-version = "0.20.0"
+version = "0.20.1"
 license = "Apache-2.0"
 authors = ["Apache Thrift Developers <dev@thrift.apache.org>"]
 homepage = "http://thrift.apache.org"

--- a/lib/swift/Sources/Thrift.swift
+++ b/lib/swift/Sources/Thrift.swift
@@ -1,3 +1,3 @@
 class Thrift {
-	let version = "0.20.0"
+	let version = "0.20.1"
 }

--- a/lib/swift/Tests/ThriftTests/ThriftTests.swift
+++ b/lib/swift/Tests/ThriftTests/ThriftTests.swift
@@ -3,7 +3,7 @@ import XCTest
 
 class ThriftTests: XCTestCase {
   func testVersion() {
-    XCTAssertEqual(Thrift().version, "0.20.0")
+    XCTAssertEqual(Thrift().version, "0.20.1")
   }
 
   static var allTests : [(String, (ThriftTests) -> () throws -> Void)] {

--- a/lib/ts/package-lock.json
+++ b/lib/ts/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thrift",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
         "bufferutil": "^4.0.1",

--- a/lib/ts/package.json
+++ b/lib/ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "description": "Thrift is a software framework for scalable cross-language services development.",
   "author": {
     "name": "Apache Thrift Developers",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "thrift",
-  "version": "0.20.0",
+  "version": "0.20.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "thrift",
-      "version": "0.20.0",
+      "version": "0.20.1",
       "license": "Apache-2.0",
       "dependencies": {
         "browser-or-node": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "type": "git",
     "url": "https://github.com/apache/thrift.git"
   },
-  "version": "0.20.0",
+  "version": "0.20.1",
   "author": {
     "name": "Apache Thrift Developers",
     "email": "dev@thrift.apache.org",

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -16,7 +16,7 @@ development, combines a software stack with a code generation engine to build
 services that work efficiently and seamlessly between all major languages.
 
 # Apache Thrift Version
-sonar.projectVersion=0.20.0
+sonar.projectVersion=0.20.1
 # use this to set another version string
 # $ sonar-runner -D sonar.projectVersion=`git rev-parse HEAD`
 # set projectDate in combination with projectVersion for imports of old releases
@@ -54,7 +54,7 @@ module1.sonar.projectName=Apache Thrift - Java Library
 module1.sonar.projectBaseDir=lib/java
 module1.sonar.sources=src
 module1.sonar.tests=test
-module1.sonar.binaries=build/libs/libthrift-0.20.0.jar
+module1.sonar.binaries=build/libs/libthrift-0.20.1.jar
 module1.sonar.libraries=build/deps/*.jar
 module1.sonar.language=java
 
@@ -62,7 +62,7 @@ module2.sonar.projectName=Apache Thrift - Java Tutorial
 module2.sonar.projectBaseDir=.
 module2.sonar.sources=tutorial/java/src, tutorial/java/gen-java
 module2.sonar.binaries=tutorial/java/tutorial.jar
-module2.sonar.libraries=lib/java/build/deps/*.jar,lib/java/build/libs/libthrift-0.20.0.jar
+module2.sonar.libraries=lib/java/build/deps/*.jar,lib/java/build/libs/libthrift-0.20.1.jar
 module2.sonar.language=java
 
 module3.sonar.projectName=Apache Thrift - JavaScript Library

--- a/test/dart/test_client/pubspec.yaml
+++ b/test/dart/test_client/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: thrift_test_client
-version: 0.20.0
+version: 0.20.1
 description: A client integration test for the Dart Thrift library
 author: Apache Thrift Developers <dev@thrift.apache.org>
 homepage: http://thrift.apache.org

--- a/test/erl/src/thrift_test.app.src
+++ b/test/erl/src/thrift_test.app.src
@@ -22,7 +22,7 @@
   {description, "Thrift cross language test"},
 
   % The version of the applicaton
-  {vsn, "0.20.0"},
+  {vsn, "0.20.1"},
 
   % All modules used by the application.
   {modules, [

--- a/test/netstd/Client/Client.csproj
+++ b/test/netstd/Client/Client.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
     <OutputType>Exe</OutputType>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/test/netstd/Server/Server.csproj
+++ b/test/netstd/Server/Server.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
     <OutputType>Exe</OutputType>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
     <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>

--- a/tutorial/dart/client/pubspec.yaml
+++ b/tutorial/dart/client/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: tutorial_client
-version: 0.20.0
+version: 0.20.1
 description: A Dart client implementation of the Apache Thrift tutorial
 author: Apache Thrift Developers <dev@thrift.apache.org>
 homepage: http://thrift.apache.org

--- a/tutorial/dart/console_client/pubspec.yaml
+++ b/tutorial/dart/console_client/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: tutorial_console_client
-version: 0.20.0
+version: 0.20.1
 description: >
   A Dart console client to implementation of the Apache Thrift tutorial
 author: Apache Thrift Developers <dev@thrift.apache.org>

--- a/tutorial/dart/server/pubspec.yaml
+++ b/tutorial/dart/server/pubspec.yaml
@@ -16,7 +16,7 @@
 # under the License.
 
 name: tutorial_server
-version: 0.20.0
+version: 0.20.1
 description: A Dart server to support the Apache Thrift tutorial
 author: Apache Thrift Developers <dev@thrift.apache.org>
 homepage: http://thrift.apache.org

--- a/tutorial/delphi/DelphiClient/DelphiClient.dproj
+++ b/tutorial/delphi/DelphiClient/DelphiClient.dproj
@@ -124,13 +124,13 @@ popd]]></PreBuildEvent>
 					<VersionInfoKeys>
 						<VersionInfoKeys Name="CompanyName"/>
 						<VersionInfoKeys Name="FileDescription">Thrift Tutorial</VersionInfoKeys>
-						<VersionInfoKeys Name="FileVersion">0.20.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="FileVersion">0.20.1.0</VersionInfoKeys>
 						<VersionInfoKeys Name="InternalName">DelphiClient</VersionInfoKeys>
 						<VersionInfoKeys Name="LegalCopyright">Copyright © 2012 The Apache Software Foundation</VersionInfoKeys>
 						<VersionInfoKeys Name="LegalTrademarks"/>
 						<VersionInfoKeys Name="OriginalFilename">DelphiClient.exe</VersionInfoKeys>
 						<VersionInfoKeys Name="ProductName">Thrift</VersionInfoKeys>
-						<VersionInfoKeys Name="ProductVersion">0.20.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="ProductVersion">0.20.1.0</VersionInfoKeys>
 						<VersionInfoKeys Name="Comments"/>
 					</VersionInfoKeys>
 					<Source>

--- a/tutorial/delphi/DelphiServer/DelphiServer.dproj
+++ b/tutorial/delphi/DelphiServer/DelphiServer.dproj
@@ -121,13 +121,13 @@ popd]]></PreBuildEvent>
 					<VersionInfoKeys>
 						<VersionInfoKeys Name="CompanyName"/>
 						<VersionInfoKeys Name="FileDescription">Thrift Tutorial</VersionInfoKeys>
-						<VersionInfoKeys Name="FileVersion">0.20.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="FileVersion">0.20.1.0</VersionInfoKeys>
 						<VersionInfoKeys Name="InternalName">DelphiServer</VersionInfoKeys>
 						<VersionInfoKeys Name="LegalCopyright">Copyright © 2012 The Apache Software Foundation</VersionInfoKeys>
 						<VersionInfoKeys Name="LegalTrademarks"/>
 						<VersionInfoKeys Name="OriginalFilename">DelphiServer.exe</VersionInfoKeys>
 						<VersionInfoKeys Name="ProductName">Thrift</VersionInfoKeys>
-						<VersionInfoKeys Name="ProductVersion">0.20.0.0</VersionInfoKeys>
+						<VersionInfoKeys Name="ProductVersion">0.20.1.0</VersionInfoKeys>
 						<VersionInfoKeys Name="Comments"/>
 					</VersionInfoKeys>
 					<Source>

--- a/tutorial/netstd/Client/Client.csproj
+++ b/tutorial/netstd/Client/Client.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
     <AssemblyName>Client</AssemblyName>
     <PackageId>Client</PackageId>
     <OutputType>Exe</OutputType>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tutorial/netstd/Interfaces/Interfaces.csproj
+++ b/tutorial/netstd/Interfaces/Interfaces.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -22,7 +22,7 @@
     <TargetFramework>net6.0</TargetFramework>
     <AssemblyName>Interfaces</AssemblyName>
     <PackageId>Interfaces</PackageId>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tutorial/netstd/Server/Server.csproj
+++ b/tutorial/netstd/Server/Server.csproj
@@ -7,9 +7,9 @@
     to you under the Apache License, Version 2.0 (the
     "License"); you may not use this file except in compliance
     with the License. You may obtain a copy of the License at
-    
+
   	  http://www.apache.org/licenses/LICENSE-2.0
-    
+
     Unless required by applicable law or agreed to in writing,
     software distributed under the License is distributed on an
     "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
@@ -24,7 +24,7 @@
     <AssemblyName>Server</AssemblyName>
     <PackageId>Server</PackageId>
     <OutputType>Exe</OutputType>
-    <Version>0.20.0.0</Version>
+    <Version>0.20.1.0</Version>
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>

--- a/tutorial/ocaml/_oasis
+++ b/tutorial/ocaml/_oasis
@@ -1,5 +1,5 @@
 Name: tutorial
-Version: 0.20.0
+Version: 0.20.1
 OASISFormat: 0.3
 Synopsis: OCaml Tutorial example
 Authors: Apache Thrift Developers <dev@thrift.apache.org>


### PR DESCRIPTION
Причина изменений: 
При наличии в перечне методов из протокола thrift аргументов с именем callback ловим ошибку при генерации кода на JS . Все из-за того что JS добавляет специальный параметр callback в список аргументов. Получается [ошибка](https://github.com/valitydev/damsel/actions/runs/23546341508/job/68547588351?pr=206)

Предлагается изменение названия параметра callback при совпадении с именем одного из параметров метода. По аналогии с [params](https://github.com/valitydev/thrift/blob/master/compiler/cpp/src/thrift/generate/t_js_generator.cc#L1988)